### PR TITLE
Include output in .NET 6 build to ensure that runtime framework version upgrades work.

### DIFF
--- a/DateTimeOnly/DateTimeOnly.csproj
+++ b/DateTimeOnly/DateTimeOnly.csproj
@@ -100,7 +100,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="Resources\_._" Pack="true" PackagePath="lib\net6.0\" />
     <None Include="..\Icon.png" Pack="true" PackagePath="icon.png" />
     <None Include="..\README.md" Pack="true" PackagePath="\" />
     <None Remove="DateTimeOnly.csproj.DotSettings" />
@@ -112,7 +111,6 @@
 
   <Target Name="RemoveNet6" AfterTargets="_WalkEachTargetPerFramework">
     <ItemGroup>
-      <_BuildOutputInPackage Remove="$(MSBuildThisFileDirectory)$(IntermediateOutputPath)net6.0\$(AssemblyName).*" Pack="false" />
       <_BuildOutputInPackage Remove="$(MSBuildThisFileDirectory)$(DocumentationFile)" Pack="false" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
This fixes an unresolved runtime issue in #8.

Specifically, a runtime dll not found exception will be thrown for `Portable.System.DateTimeOnly.dll` when all of the following conditions are met:
1. Project `A` has a `PackageReference` to `Portable.System.DateTimeOnly`.
2. Project `A` is compiled against `net5.0` or an earlier version.
   * Project `A` may be compiled against multiple versions, provided it's not compiled against `net6.0` (or higher).
3. Project `B` as a reference to project `A`.
   * This could be via a `ProjectReference` or a `PackageReference`.
4. Project `B` is compiled against `net6.0` or a later version. 
    * Project `B` can be compiled against multiple versions as well and all versions after `net5.0` will also fail unless if project `A` is also compiled against that version that is less than the target version of project `B` but greater than `net5.0`

This just adds the build output back into the package for `net6.0` ensuring that the `Portable.System.DateTimeOnly` assembly is present at runtime and the `[TypeForwardedTo()]` attributes are present so that the runtime knows that types/members in Project `A` that reference `System.DateOnly` will use the native ones instead of trying to look for them in `Portable.System.DateTimeOnly`.

You can refer to [Chryssie/Portable.System.DateOnly.MinimalReplication](https://github.com/Chryssie/Portable.System.DateOnly.MinimalReplication) for a replication of the issue as it cannot be easily replicated with `ProjectReference`s to the `Portable.System.DateTimeOnly` project. Do note, it will compile successfully, the error only shows up if you run it which will give you a:

```
System.IO.FileNotFoundException: 'Could not load file or assembly 'Portable.System.DateTimeOnly, Version=6.0.3.0, Culture=neutral, PublicKeyToken=16fb7a27ac3b9689'. The system cannot find the file specified.'
```