### PR TITLE
Throw ArgumentException for invalid DateTimeStyles in TryParse/TryParseExact

### DIFF
--- a/DateTimeOnly.Tests/ArgumentValidationTests.cs
+++ b/DateTimeOnly.Tests/ArgumentValidationTests.cs
@@ -77,6 +77,12 @@ public sealed class ArgumentValidationTests
 
         Assert.False(DateOnly.TryParse("aa-bb-cc", out dateOnly));
         Assert.Equal(default, dateOnly);
+
+        Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
+            () => DateOnly.TryParse("aa-bb-cc".AsSpan(), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out dateOnly)).ParamName);
+
+        Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
+            () => DateOnly.TryParse("aa-bb-cc", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out dateOnly)).ParamName);
     }
 
     [Fact]
@@ -131,13 +137,17 @@ public sealed class ArgumentValidationTests
             DateTimeStyles.AllowWhiteSpaces, out dateOnly));
         Assert.Equal(default, dateOnly);
 
-        Assert.False(DateOnly.TryParseExact(
-            string.Empty, string.Empty, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out dateOnly));
-        Assert.Equal(default, dateOnly);
+        Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
+            () => DateOnly.TryParseExact(
+                string.Empty, string.Empty, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out dateOnly)).ParamName);
 
-        Assert.False(DateOnly.TryParseExact(
-            new ReadOnlySpan<char>(), string.Empty.AsSpan(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out dateOnly));
-        Assert.Equal(default, dateOnly);
+        Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
+            () => DateOnly.TryParseExact(
+                new ReadOnlySpan<char>(), string.Empty.AsSpan(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out dateOnly)).ParamName);
+
+        Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
+            () => DateOnly.TryParseExact(
+                string.Empty, [string.Empty], CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out dateOnly)).ParamName);
 
         Assert.False(DateOnly.TryParseExact("aa-bb-cc", "dd-MM-YY", out dateOnly));
         Assert.Equal(default, dateOnly);
@@ -201,6 +211,12 @@ public sealed class ArgumentValidationTests
 
         Assert.False(TimeOnly.TryParse("aa:bb", out timeOnly));
         Assert.Equal(default, timeOnly);
+
+        Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
+            () => TimeOnly.TryParse("aa:bb".AsSpan(), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out timeOnly)).ParamName);
+
+        Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
+            () => TimeOnly.TryParse("aa:bb", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out timeOnly)).ParamName);
     }
 
     [Fact]
@@ -255,13 +271,17 @@ public sealed class ArgumentValidationTests
             DateTimeStyles.AllowWhiteSpaces, out timeOnly));
         Assert.Equal(default, timeOnly);
 
-        Assert.False(TimeOnly.TryParseExact(
-            string.Empty, string.Empty, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out timeOnly));
-        Assert.Equal(default, timeOnly);
+        Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
+            () => TimeOnly.TryParseExact(
+                string.Empty, string.Empty, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out timeOnly)).ParamName);
 
-        Assert.False(TimeOnly.TryParseExact(
-            new ReadOnlySpan<char>(), string.Empty.AsSpan(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out timeOnly));
-        Assert.Equal(default, timeOnly);
+        Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
+            () => TimeOnly.TryParseExact(
+                new ReadOnlySpan<char>(), string.Empty.AsSpan(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out timeOnly)).ParamName);
+
+        Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
+            () => TimeOnly.TryParseExact(
+                string.Empty, [string.Empty], CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out timeOnly)).ParamName);
 
         Assert.False(TimeOnly.TryParseExact("aa-bb-cc", "dd-MM-YY", out timeOnly));
         Assert.Equal(default, timeOnly);

--- a/DateTimeOnly.Tests/DateOnlyTests.cs
+++ b/DateTimeOnly.Tests/DateOnlyTests.cs
@@ -353,13 +353,13 @@ public class DateOnlyTests
         Assert.Equal(dateOnly, parsedDateOnly);
         Assert.Equal(dateOnly, parsedDateOnly1);
 
-        Assert.False(DateOnly.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out parsedDateOnly1));
+        Assert.Throws<ArgumentException>(() => DateOnly.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out parsedDateOnly1));
         Assert.Throws<ArgumentException>(() => DateOnly.Parse(s, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal));
-        Assert.False(DateOnly.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out parsedDateOnly1));
+        Assert.Throws<ArgumentException>(() => DateOnly.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out parsedDateOnly1));
         Assert.Throws<ArgumentException>(() => DateOnly.Parse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal));
-        Assert.False(DateOnly.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out parsedDateOnly1));
+        Assert.Throws<ArgumentException>(() => DateOnly.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out parsedDateOnly1));
         Assert.Throws<ArgumentException>(() => DateOnly.Parse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal));
-        Assert.False(DateOnly.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault, out parsedDateOnly1));
+        Assert.Throws<ArgumentException>(() => DateOnly.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault, out parsedDateOnly1));
         Assert.Throws<ArgumentException>(() => DateOnly.Parse(s, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault));
 
         s = "     " + s + "     ";

--- a/DateTimeOnly.Tests/TimeOnlyTests.cs
+++ b/DateTimeOnly.Tests/TimeOnlyTests.cs
@@ -391,13 +391,13 @@ public class TimeOnlyTests
         Assert.True(TimeOnly.TryParse(s.AsSpan(), CultureInfo.InvariantCulture, DateTimeStyles.None, out parsedTimeOnly1));
         Assert.Equal(parsedTimeOnly, parsedTimeOnly1);
 
-        Assert.False(TimeOnly.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out parsedTimeOnly1));
+        AssertExtensions.Throws<ArgumentException>("style", () => TimeOnly.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out parsedTimeOnly1));
         AssertExtensions.Throws<ArgumentException>("style", () => TimeOnly.Parse(s, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal));
-        Assert.False(TimeOnly.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out parsedTimeOnly1));
+        AssertExtensions.Throws<ArgumentException>("style", () => TimeOnly.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out parsedTimeOnly1));
         AssertExtensions.Throws<ArgumentException>("style", () => TimeOnly.Parse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal));
-        Assert.False(TimeOnly.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out parsedTimeOnly1));
+        AssertExtensions.Throws<ArgumentException>("style", () => TimeOnly.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out parsedTimeOnly1));
         AssertExtensions.Throws<ArgumentException>("style", () => TimeOnly.Parse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal));
-        Assert.False(TimeOnly.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault, out parsedTimeOnly1));
+        AssertExtensions.Throws<ArgumentException>("style", () => TimeOnly.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault, out parsedTimeOnly1));
         AssertExtensions.Throws<ArgumentException>("style", () => TimeOnly.Parse(s, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault));
 
         s = "     " + s + "     ";

--- a/DateTimeOnly/DateOnly.cs
+++ b/DateTimeOnly/DateOnly.cs
@@ -436,7 +436,15 @@ namespace System
         /// <param name="style">A bitwise combination of enumeration values that indicates the permitted format of s. A typical value to specify is None.</param>
         /// <param name="result">When this method returns, contains the DateOnly value equivalent to the date contained in s, if the conversion succeeded, or MinValue if the conversion failed. The conversion fails if the s parameter is empty string, or does not contain a valid string representation of a date. This parameter is passed uninitialized.</param>
         /// <returns>true if the s parameter was converted successfully; otherwise, false.</returns>
-        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, DateTimeStyles style, out DateOnly result) => TryParseInternal(s, provider, style, out result) == ParseFailureKind.None;
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, DateTimeStyles style, out DateOnly result)
+        {
+            if ((style & ~DateTimeStyles.AllowWhiteSpaces) != 0)
+            {
+                throw new ArgumentException(SR.Argument_InvalidDateStyles, nameof(style));
+            }
+
+            return TryParseInternal(s, provider, style, out result) == ParseFailureKind.None;
+        }
 
         private static ParseFailureKind TryParseInternal(ReadOnlySpan<char> s, IFormatProvider? provider, DateTimeStyles style, out DateOnly result)
         {
@@ -485,8 +493,15 @@ namespace System
         /// <param name="style">A bitwise combination of one or more enumeration values that indicate the permitted format of s.</param>
         /// <param name="result">When this method returns, contains the DateOnly value equivalent to the date contained in s, if the conversion succeeded, or MinValue if the conversion failed. The conversion fails if the s is empty string, or does not contain a date that correspond to the pattern specified in format. This parameter is passed uninitialized.</param>
         /// <returns>true if s was converted successfully; otherwise, false.</returns>
-        public static bool TryParseExact(ReadOnlySpan<char> s, [StringSyntax(StringSyntaxAttribute.DateOnlyFormat)] ReadOnlySpan<char> format, IFormatProvider? provider, DateTimeStyles style, out DateOnly result) =>
-                            TryParseExactInternal(s, format, provider, style, out result) == ParseFailureKind.None;
+        public static bool TryParseExact(ReadOnlySpan<char> s, [StringSyntax(StringSyntaxAttribute.DateOnlyFormat)] ReadOnlySpan<char> format, IFormatProvider? provider, DateTimeStyles style, out DateOnly result)
+        {
+            if ((style & ~DateTimeStyles.AllowWhiteSpaces) != 0)
+            {
+                throw new ArgumentException(SR.Argument_InvalidDateStyles, nameof(style));
+            }
+
+            return TryParseExactInternal(s, format, provider, style, out result) == ParseFailureKind.None;
+        }
         private static ParseFailureKind TryParseExactInternal(ReadOnlySpan<char> s, ReadOnlySpan<char> format, IFormatProvider? provider, DateTimeStyles style, out DateOnly result)
         {
             if ((style & ~DateTimeStyles.AllowWhiteSpaces) != 0)
@@ -549,8 +564,15 @@ namespace System
         /// <param name="style">A bitwise combination of enumeration values that defines how to interpret the parsed date. A typical value to specify is None.</param>
         /// <param name="result">When this method returns, contains the DateOnly value equivalent to the date contained in s, if the conversion succeeded, or MinValue if the conversion failed. The conversion fails if the s parameter is Empty, or does not contain a valid string representation of a date. This parameter is passed uninitialized.</param>
         /// <returns>true if the s parameter was converted successfully; otherwise, false.</returns>
-        public static bool TryParseExact(ReadOnlySpan<char> s, [NotNullWhen(true), StringSyntax(StringSyntaxAttribute.DateOnlyFormat)] string?[]? formats, IFormatProvider? provider, DateTimeStyles style, out DateOnly result) =>
-                            TryParseExactInternal(s, formats, provider, style, out result) == ParseFailureKind.None;
+        public static bool TryParseExact(ReadOnlySpan<char> s, [NotNullWhen(true), StringSyntax(StringSyntaxAttribute.DateOnlyFormat)] string?[]? formats, IFormatProvider? provider, DateTimeStyles style, out DateOnly result)
+        {
+            if ((style & ~DateTimeStyles.AllowWhiteSpaces) != 0)
+            {
+                throw new ArgumentException(SR.Argument_InvalidDateStyles, nameof(style));
+            }
+
+            return TryParseExactInternal(s, formats, provider, style, out result) == ParseFailureKind.None;
+        }
 
         private static ParseFailureKind TryParseExactInternal(ReadOnlySpan<char> s, string?[]? formats, IFormatProvider? provider, DateTimeStyles style, out DateOnly result)
         {

--- a/DateTimeOnly/TimeOnly.cs
+++ b/DateTimeOnly/TimeOnly.cs
@@ -603,8 +603,15 @@ namespace System
         /// <param name="result">When this method returns, contains the TimeOnly value equivalent to the time contained in s, if the conversion succeeded, or MinValue if the conversion failed. The conversion fails if the s parameter is empty string, or does not contain a valid string representation of a date. This parameter is passed uninitialized.</param>
         /// <returns>true if the s parameter was converted successfully; otherwise, false.</returns>
         /// <inheritdoc cref="ISpanParsable{TSelf}.TryParse(ReadOnlySpan{char}, IFormatProvider?, out TSelf)" />
-        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, DateTimeStyles style, out TimeOnly result) =>
-                            TryParseInternal(s, provider, style, out result) == ParseFailureKind.None;
+        public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, DateTimeStyles style, out TimeOnly result)
+        {
+            if ((style & ~DateTimeStyles.AllowWhiteSpaces) != 0)
+            {
+                throw new ArgumentException(SR.Argument_InvalidDateStyles, nameof(style));
+            }
+
+            return TryParseInternal(s, provider, style, out result) == ParseFailureKind.None;
+        }
         private static ParseFailureKind TryParseInternal(ReadOnlySpan<char> s, IFormatProvider? provider, DateTimeStyles style, out TimeOnly result)
         {
             if ((style & ~DateTimeStyles.AllowWhiteSpaces) != 0)
@@ -654,8 +661,15 @@ namespace System
         /// <param name="style">A bitwise combination of one or more enumeration values that indicate the permitted format of s.</param>
         /// <param name="result">When this method returns, contains the TimeOnly value equivalent to the time contained in s, if the conversion succeeded, or MinValue if the conversion failed. The conversion fails if the s is empty string, or does not contain a time that correspond to the pattern specified in format. This parameter is passed uninitialized.</param>
         /// <returns>true if s was converted successfully; otherwise, false.</returns>
-        public static bool TryParseExact(ReadOnlySpan<char> s, [StringSyntax(StringSyntaxAttribute.TimeOnlyFormat)] ReadOnlySpan<char> format, IFormatProvider? provider, DateTimeStyles style, out TimeOnly result) =>
-                            TryParseExactInternal(s, format, provider, style, out result) == ParseFailureKind.None;
+        public static bool TryParseExact(ReadOnlySpan<char> s, [StringSyntax(StringSyntaxAttribute.TimeOnlyFormat)] ReadOnlySpan<char> format, IFormatProvider? provider, DateTimeStyles style, out TimeOnly result)
+        {
+            if ((style & ~DateTimeStyles.AllowWhiteSpaces) != 0)
+            {
+                throw new ArgumentException(SR.Argument_InvalidDateStyles, nameof(style));
+            }
+
+            return TryParseExactInternal(s, format, provider, style, out result) == ParseFailureKind.None;
+        }
 
         private static ParseFailureKind TryParseExactInternal(ReadOnlySpan<char> s, ReadOnlySpan<char> format, IFormatProvider? provider, DateTimeStyles style, out TimeOnly result)
         {
@@ -719,8 +733,15 @@ namespace System
         /// <param name="style">A bitwise combination of enumeration values that defines how to interpret the parsed time. A typical value to specify is None.</param>
         /// <param name="result">When this method returns, contains the TimeOnly value equivalent to the time contained in s, if the conversion succeeded, or MinValue if the conversion failed. The conversion fails if the s parameter is Empty, or does not contain a valid string representation of a time. This parameter is passed uninitialized.</param>
         /// <returns>true if the s parameter was converted successfully; otherwise, false.</returns>
-        public static bool TryParseExact(ReadOnlySpan<char> s, [NotNullWhen(true), StringSyntax(StringSyntaxAttribute.TimeOnlyFormat)] string?[]? formats, IFormatProvider? provider, DateTimeStyles style, out TimeOnly result) =>
-            TryParseExactInternal(s, formats, provider, style, out result) == ParseFailureKind.None;
+        public static bool TryParseExact(ReadOnlySpan<char> s, [NotNullWhen(true), StringSyntax(StringSyntaxAttribute.TimeOnlyFormat)] string?[]? formats, IFormatProvider? provider, DateTimeStyles style, out TimeOnly result)
+        {
+            if ((style & ~DateTimeStyles.AllowWhiteSpaces) != 0)
+            {
+                throw new ArgumentException(SR.Argument_InvalidDateStyles, nameof(style));
+            }
+
+            return TryParseExactInternal(s, formats, provider, style, out result) == ParseFailureKind.None;
+        }
 
         private static ParseFailureKind TryParseExactInternal(ReadOnlySpan<char> s, string?[]? formats, IFormatProvider? provider, DateTimeStyles style, out TimeOnly result)
         {


### PR DESCRIPTION
## Summary

Closes #117.

`DateOnly`/`TimeOnly` `TryParse` and `TryParseExact` (span-based overloads) silently returned `false` for a `DateTimeStyles` value outside `AllowWhiteSpaces`, instead of throwing `ArgumentException` like `Parse`/`ParseExact` already do and like upstream `dotnet/runtime`'s `DateOnly`/`TimeOnly.TryParse` now does.

- Added the same up-front `(style & ~DateTimeStyles.AllowWhiteSpaces) != 0` check used by `Parse`/`ParseExact` to the three span-based `Try*` entry points on both types:
  - `TryParse(ReadOnlySpan<char>, IFormatProvider?, DateTimeStyles, out T)`
  - `TryParseExact(ReadOnlySpan<char>, ReadOnlySpan<char>, IFormatProvider?, DateTimeStyles, out T)`
  - `TryParseExact(ReadOnlySpan<char>, string?[]?, IFormatProvider?, DateTimeStyles, out T)`
- The `string`-based overloads delegate into these, so they pick up the fix automatically once their `s`/`format`/`formats` null checks pass.
- Scope intentionally limited to the `DateTimeStyles` validation gap (#117). The separate `formats[]` up-front validation gap (#118) and the malformed-format-string gap (#119) are not touched here.

## Tests

- Fixed two pre-existing tests in `DateOnlyTests.cs`/`TimeOnlyTests.cs` (`BasicFormatParseTest`) that literally asserted the old buggy `TryParse` behavior (`Assert.False(...)`) right next to a correct `Parse` assertion (`Assert.Throws<ArgumentException>(...)`) for the same invalid style — now both assert the throw.
- Updated `ArgumentValidationTests.cs`: two existing `TryParseExact` assertions that used an invalid style (`AssumeUniversal`/`AssumeLocal`) with non-null input now expect `ArgumentException` instead of `false`.
- Added new coverage for the `TryParse(span/string)` and `TryParseExact(formats[])` overloads with an invalid style, since none of those specific paths had a non-null-input test before.

## Test plan

- [x] `dotnet build -c Debug` — succeeds, 0 warnings/errors
- [x] `dotnet test` — 169/169 passed