### PR TITLE
Validate the entire formats[] array up front in ParseExact/TryParseExact

### DIFF
--- a/DateTimeOnly.Tests/ArgumentValidationTests.cs
+++ b/DateTimeOnly.Tests/ArgumentValidationTests.cs
@@ -289,10 +289,10 @@ public sealed class ArgumentValidationTests
 
         // a bad trailing entry must be caught even if an earlier format would have matched
         Assert.Throws<FormatException>(() => TimeOnly.ParseExact(
-            TimeOnlyValue.ToString("HH:mm:ss"), ["HH:mm:ss", string.Empty], CultureInfo.InvariantCulture));
+            TimeOnlyValue.ToString("HH:mm:ss", CultureInfo.InvariantCulture), ["HH:mm:ss", string.Empty], CultureInfo.InvariantCulture));
 
         Assert.Throws<FormatException>(() => TimeOnly.TryParseExact(
-            TimeOnlyValue.ToString("HH:mm:ss").AsSpan(), ["HH:mm:ss", string.Empty], CultureInfo.InvariantCulture,
+            TimeOnlyValue.ToString("HH:mm:ss", CultureInfo.InvariantCulture).AsSpan(), ["HH:mm:ss", string.Empty], CultureInfo.InvariantCulture,
             DateTimeStyles.None, out timeOnly));
 
         Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(

--- a/DateTimeOnly.Tests/ArgumentValidationTests.cs
+++ b/DateTimeOnly.Tests/ArgumentValidationTests.cs
@@ -106,6 +106,11 @@ public sealed class ArgumentValidationTests
 
         Assert.Throws<FormatException>(() => DateOnly.ParseExact(
             string.Empty, [string.Empty], CultureInfo.InvariantCulture));
+
+        // invalid style must take priority over a bad formats entry, not the other way around
+        Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
+            () => DateOnly.ParseExact(
+                string.Empty, [string.Empty], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)).ParamName);
     }
 
     [Fact]
@@ -127,15 +132,22 @@ public sealed class ArgumentValidationTests
             string.Empty, NullStringArray, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out dateOnly));
         Assert.Equal(default, dateOnly);
 
+        Assert.Throws<FormatException>(() => DateOnly.TryParseExact(
+            [], [string.Empty], CultureInfo.InvariantCulture,
+            DateTimeStyles.AllowWhiteSpaces, out dateOnly));
+
         Assert.False(DateOnly.TryParseExact(
-            [], [string.Empty], CultureInfo.InvariantCulture, 
+            [], Array.Empty<string>(), CultureInfo.InvariantCulture,
             DateTimeStyles.AllowWhiteSpaces, out dateOnly));
         Assert.Equal(default, dateOnly);
 
-        Assert.False(DateOnly.TryParseExact(
-            [], Array.Empty<string>(), CultureInfo.InvariantCulture, 
-            DateTimeStyles.AllowWhiteSpaces, out dateOnly));
-        Assert.Equal(default, dateOnly);
+        // a bad trailing entry must be caught even if an earlier format would have matched
+        Assert.Throws<FormatException>(() => DateOnly.ParseExact(
+            DateOnlyValue.ToString("yyyy-MM-dd"), ["yyyy-MM-dd", string.Empty], CultureInfo.InvariantCulture));
+
+        Assert.Throws<FormatException>(() => DateOnly.TryParseExact(
+            DateOnlyValue.ToString("yyyy-MM-dd").AsSpan(), ["yyyy-MM-dd", string.Empty], CultureInfo.InvariantCulture,
+            DateTimeStyles.None, out dateOnly));
 
         Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
             () => DateOnly.TryParseExact(
@@ -240,6 +252,11 @@ public sealed class ArgumentValidationTests
 
         Assert.Throws<FormatException>(() => TimeOnly.ParseExact(
             string.Empty, [string.Empty], CultureInfo.InvariantCulture));
+
+        // invalid style must take priority over a bad formats entry, not the other way around
+        Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
+            () => TimeOnly.ParseExact(
+                string.Empty, [string.Empty], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)).ParamName);
     }
 
     [Fact]
@@ -261,15 +278,22 @@ public sealed class ArgumentValidationTests
             string.Empty, NullStringArray, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out timeOnly));
         Assert.Equal(default, timeOnly);
 
+        Assert.Throws<FormatException>(() => TimeOnly.TryParseExact(
+            [], [string.Empty], CultureInfo.InvariantCulture,
+            DateTimeStyles.AllowWhiteSpaces, out timeOnly));
+
         Assert.False(TimeOnly.TryParseExact(
-            [], [string.Empty], CultureInfo.InvariantCulture, 
+            [], Array.Empty<string>(), CultureInfo.InvariantCulture,
             DateTimeStyles.AllowWhiteSpaces, out timeOnly));
         Assert.Equal(default, timeOnly);
 
-        Assert.False(TimeOnly.TryParseExact(
-            [], Array.Empty<string>(), CultureInfo.InvariantCulture, 
-            DateTimeStyles.AllowWhiteSpaces, out timeOnly));
-        Assert.Equal(default, timeOnly);
+        // a bad trailing entry must be caught even if an earlier format would have matched
+        Assert.Throws<FormatException>(() => TimeOnly.ParseExact(
+            TimeOnlyValue.ToString("HH:mm:ss"), ["HH:mm:ss", string.Empty], CultureInfo.InvariantCulture));
+
+        Assert.Throws<FormatException>(() => TimeOnly.TryParseExact(
+            TimeOnlyValue.ToString("HH:mm:ss").AsSpan(), ["HH:mm:ss", string.Empty], CultureInfo.InvariantCulture,
+            DateTimeStyles.None, out timeOnly));
 
         Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
             () => TimeOnly.TryParseExact(

--- a/DateTimeOnly/DateOnly.cs
+++ b/DateTimeOnly/DateOnly.cs
@@ -342,6 +342,11 @@ namespace System
         /// <returns>An object that is equivalent to the date contained in s, as specified by format, provider, and style.</returns>
         public static DateOnly ParseExact(ReadOnlySpan<char> s, [StringSyntax(StringSyntaxAttribute.DateOnlyFormat)] string[] formats, IFormatProvider? provider, DateTimeStyles style = DateTimeStyles.None)
         {
+            if ((style & ~DateTimeStyles.AllowWhiteSpaces) == 0)
+            {
+                ThrowOnBadFormatSpecifier(formats);
+            }
+
             ParseFailureKind result = TryParseExactInternal(s, formats, provider, style, out DateOnly dateOnly);
             if (result != ParseFailureKind.None)
             {
@@ -571,7 +576,25 @@ namespace System
                 throw new ArgumentException(SR.Argument_InvalidDateStyles, nameof(style));
             }
 
+            ThrowOnBadFormatSpecifier(formats);
+
             return TryParseExactInternal(s, formats, provider, style, out result) == ParseFailureKind.None;
+        }
+
+        private static void ThrowOnBadFormatSpecifier(string?[]? formats)
+        {
+            if (formats == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < formats.Length; i++)
+            {
+                if (string.IsNullOrEmpty(formats[i]))
+                {
+                    throw new FormatException(SR.Argument_BadFormatSpecifier);
+                }
+            }
         }
 
         private static ParseFailureKind TryParseExactInternal(ReadOnlySpan<char> s, string?[]? formats, IFormatProvider? provider, DateTimeStyles style, out DateOnly result)

--- a/DateTimeOnly/TimeOnly.cs
+++ b/DateTimeOnly/TimeOnly.cs
@@ -508,6 +508,11 @@ namespace System
         /// <returns>An object that is equivalent to the time contained in s, as specified by format, provider, and style.</returns>
         public static TimeOnly ParseExact(ReadOnlySpan<char> s, [StringSyntax(StringSyntaxAttribute.TimeOnlyFormat)] string[] formats, IFormatProvider? provider, DateTimeStyles style = DateTimeStyles.None)
         {
+            if ((style & ~DateTimeStyles.AllowWhiteSpaces) == 0)
+            {
+                ThrowOnBadFormatSpecifier(formats);
+            }
+
             ParseFailureKind result = TryParseExactInternal(s, formats, provider, style, out TimeOnly timeOnly);
             if (result != ParseFailureKind.None)
             {
@@ -740,7 +745,25 @@ namespace System
                 throw new ArgumentException(SR.Argument_InvalidDateStyles, nameof(style));
             }
 
+            ThrowOnBadFormatSpecifier(formats);
+
             return TryParseExactInternal(s, formats, provider, style, out result) == ParseFailureKind.None;
+        }
+
+        private static void ThrowOnBadFormatSpecifier(string?[]? formats)
+        {
+            if (formats == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < formats.Length; i++)
+            {
+                if (string.IsNullOrEmpty(formats[i]))
+                {
+                    throw new FormatException(SR.Argument_BadFormatSpecifier);
+                }
+            }
         }
 
         private static ParseFailureKind TryParseExactInternal(ReadOnlySpan<char> s, string?[]? formats, IFormatProvider? provider, DateTimeStyles style, out TimeOnly result)


### PR DESCRIPTION
## Summary

Closes #118.

`DateOnly`/`TimeOnly` `ParseExact` and `TryParseExact(string/span, string[])` validated each `formats[]` entry lazily, inside the parse loop. So a null/empty trailing entry was only detected if the loop actually reached it — if an earlier entry matched the input first, the method returned successfully and the bad entry was never inspected. Upstream `dotnet/runtime`'s `DateOnly`/`TimeOnly` validate the whole array up front and throw `FormatException` immediately for any null/empty entry, regardless of position.

- Added a `ThrowOnBadFormatSpecifier(string?[]? formats)` helper (mirrors upstream's added validation pass) to both types, called from:
  - `ParseExact(ReadOnlySpan<char>, string[], IFormatProvider?, DateTimeStyles)`
  - `TryParseExact(ReadOnlySpan<char>, string?[]?, IFormatProvider?, DateTimeStyles, out T)`
- `formats == null` is left to the existing `TryParseExactInternal` check (unchanged) so the current null-formats behavior — `ArgumentException` from `ParseExact`, `false` from `TryParseExact` — is preserved exactly.
- The `string`-based overloads delegate into these span-based ones, so they inherit the fix automatically.
- Scope intentionally limited to #118. #117 (invalid `DateTimeStyles` in `Try*`) is a separate, already-open PR (#122) and isn't touched here; this branch is cut from `master`, not from that branch, so the two can merge independently.

## Tests

- Updated two existing `ArgumentValidationTests` assertions (`[], [string.Empty]` with `AllowWhiteSpaces`) that expected `false` — they now expect `FormatException`, since a non-null single-entry-bad array is exactly what up-front validation catches.
- Added the regression case that actually demonstrates the gap: `formats = ["yyyy-MM-dd", ""]` / `["HH:mm:ss", ""]` against an input the *first* format would have matched — before this fix these silently returned a parsed value, ignoring the bad trailing entry; now they throw `FormatException` for both `ParseExact` and `TryParseExact`, on both `DateOnly` and `TimeOnly`.

## Test plan

- [x] `dotnet build -c Debug` — succeeds, 0 warnings/errors
- [x] `dotnet test` — 169/169 passed