### PR TITLE
Throw FormatException for malformed custom format strings in TryParseExact

### DIFF
--- a/DateTimeOnly.Tests/ArgumentValidationTests.cs
+++ b/DateTimeOnly.Tests/ArgumentValidationTests.cs
@@ -13,8 +13,6 @@ public sealed class ArgumentValidationTests
 
     private const string FormatArgumentName = "format";
 
-    private const string BadFormatSpecifierMessage = "Format specifier was invalid.";
-
     private static readonly DateOnly DateOnlyValue = new ();
 
     private static readonly string DateOnlyStringValue = DateOnlyValue.ToString();
@@ -116,16 +114,16 @@ public sealed class ArgumentValidationTests
 
         // malformed format string (unterminated literal / dangling escape) - approximates upstream's
         // Argument_BadFormatSpecifier failure, since this backport can't detect it the same way upstream does
-        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
-            () => DateOnly.ParseExact(string.Empty, @"MM'-'\", CultureInfo.InvariantCulture)).Message);
+        Assert.Throws<FormatException>(
+            () => DateOnly.ParseExact(string.Empty, @"MM'-'\", CultureInfo.InvariantCulture));
 
-        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
-            () => DateOnly.ParseExact(string.Empty, @"\MM'", CultureInfo.InvariantCulture)).Message);
+        Assert.Throws<FormatException>(
+            () => DateOnly.ParseExact(string.Empty, @"\MM'", CultureInfo.InvariantCulture));
 
         // a malformed trailing entry must be caught even if an earlier format would have matched
-        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
+        Assert.Throws<FormatException>(
             () => DateOnly.ParseExact(
-                DateOnlyValue.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), ["yyyy-MM-dd", @"MM'-'\"], CultureInfo.InvariantCulture)).Message);
+                DateOnlyValue.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), ["yyyy-MM-dd", @"MM'-'\"], CultureInfo.InvariantCulture));
 
         // invalid style must take priority over a malformed format, not the other way around
         Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
@@ -181,17 +179,17 @@ public sealed class ArgumentValidationTests
                 string.Empty, [string.Empty], CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out dateOnly)).ParamName);
 
         // malformed format string - TryParseExact must now throw instead of silently returning false
-        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
-            () => DateOnly.TryParseExact(string.Empty, @"MM'-'\", CultureInfo.InvariantCulture, DateTimeStyles.None, out dateOnly)).Message);
+        Assert.Throws<FormatException>(
+            () => DateOnly.TryParseExact(string.Empty, @"MM'-'\", CultureInfo.InvariantCulture, DateTimeStyles.None, out dateOnly));
 
-        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
-            () => DateOnly.TryParseExact(string.Empty.AsSpan(), @"\MM'".AsSpan(), CultureInfo.InvariantCulture, DateTimeStyles.None, out dateOnly)).Message);
+        Assert.Throws<FormatException>(
+            () => DateOnly.TryParseExact(string.Empty.AsSpan(), @"\MM'".AsSpan(), CultureInfo.InvariantCulture, DateTimeStyles.None, out dateOnly));
 
         // a malformed trailing entry must be caught even if an earlier format would have matched
-        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
+        Assert.Throws<FormatException>(
             () => DateOnly.TryParseExact(
                 DateOnlyValue.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), ["yyyy-MM-dd", @"MM'-'\"], CultureInfo.InvariantCulture,
-                DateTimeStyles.None, out dateOnly)).Message);
+                DateTimeStyles.None, out dateOnly));
 
         // invalid style must take priority over a malformed format, not the other way around
         Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
@@ -296,16 +294,16 @@ public sealed class ArgumentValidationTests
 
         // malformed format string (unterminated literal / dangling escape) - approximates upstream's
         // Argument_BadFormatSpecifier failure, since this backport can't detect it the same way upstream does
-        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
-            () => TimeOnly.ParseExact(string.Empty, @"mm'-'\", CultureInfo.InvariantCulture)).Message);
+        Assert.Throws<FormatException>(
+            () => TimeOnly.ParseExact(string.Empty, @"mm'-'\", CultureInfo.InvariantCulture));
 
-        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
-            () => TimeOnly.ParseExact(string.Empty, @"\mm'", CultureInfo.InvariantCulture)).Message);
+        Assert.Throws<FormatException>(
+            () => TimeOnly.ParseExact(string.Empty, @"\mm'", CultureInfo.InvariantCulture));
 
         // a malformed trailing entry must be caught even if an earlier format would have matched
-        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
+        Assert.Throws<FormatException>(
             () => TimeOnly.ParseExact(
-                TimeOnlyValue.ToString("HH:mm:ss", CultureInfo.InvariantCulture), ["HH:mm:ss", @"mm'-'\"], CultureInfo.InvariantCulture)).Message);
+                TimeOnlyValue.ToString("HH:mm:ss", CultureInfo.InvariantCulture), ["HH:mm:ss", @"mm'-'\"], CultureInfo.InvariantCulture));
 
         // invalid style must take priority over a malformed format, not the other way around
         Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
@@ -361,17 +359,17 @@ public sealed class ArgumentValidationTests
                 string.Empty, [string.Empty], CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out timeOnly)).ParamName);
 
         // malformed format string - TryParseExact must now throw instead of silently returning false
-        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
-            () => TimeOnly.TryParseExact(string.Empty, @"mm'-'\", CultureInfo.InvariantCulture, DateTimeStyles.None, out timeOnly)).Message);
+        Assert.Throws<FormatException>(
+            () => TimeOnly.TryParseExact(string.Empty, @"mm'-'\", CultureInfo.InvariantCulture, DateTimeStyles.None, out timeOnly));
 
-        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
-            () => TimeOnly.TryParseExact(string.Empty.AsSpan(), @"\mm'".AsSpan(), CultureInfo.InvariantCulture, DateTimeStyles.None, out timeOnly)).Message);
+        Assert.Throws<FormatException>(
+            () => TimeOnly.TryParseExact(string.Empty.AsSpan(), @"\mm'".AsSpan(), CultureInfo.InvariantCulture, DateTimeStyles.None, out timeOnly));
 
         // a malformed trailing entry must be caught even if an earlier format would have matched
-        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
+        Assert.Throws<FormatException>(
             () => TimeOnly.TryParseExact(
                 TimeOnlyValue.ToString("HH:mm:ss", CultureInfo.InvariantCulture), ["HH:mm:ss", @"mm'-'\"], CultureInfo.InvariantCulture,
-                DateTimeStyles.None, out timeOnly)).Message);
+                DateTimeStyles.None, out timeOnly));
 
         // invalid style must take priority over a malformed format, not the other way around
         Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(

--- a/DateTimeOnly.Tests/ArgumentValidationTests.cs
+++ b/DateTimeOnly.Tests/ArgumentValidationTests.cs
@@ -13,6 +13,8 @@ public sealed class ArgumentValidationTests
 
     private const string FormatArgumentName = "format";
 
+    private const string BadFormatSpecifierMessage = "Format specifier was invalid.";
+
     private static readonly DateOnly DateOnlyValue = new ();
 
     private static readonly string DateOnlyStringValue = DateOnlyValue.ToString();
@@ -111,6 +113,23 @@ public sealed class ArgumentValidationTests
         Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
             () => DateOnly.ParseExact(
                 string.Empty, [string.Empty], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)).ParamName);
+
+        // malformed format string (unterminated literal / dangling escape) - approximates upstream's
+        // Argument_BadFormatSpecifier failure, since this backport can't detect it the same way upstream does
+        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
+            () => DateOnly.ParseExact(string.Empty, @"MM'-'\", CultureInfo.InvariantCulture)).Message);
+
+        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
+            () => DateOnly.ParseExact(string.Empty, @"\MM'", CultureInfo.InvariantCulture)).Message);
+
+        // a malformed trailing entry must be caught even if an earlier format would have matched
+        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
+            () => DateOnly.ParseExact(
+                DateOnlyValue.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), ["yyyy-MM-dd", @"MM'-'\"], CultureInfo.InvariantCulture)).Message);
+
+        // invalid style must take priority over a malformed format, not the other way around
+        Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
+            () => DateOnly.ParseExact(string.Empty, @"MM'-'\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)).ParamName);
     }
 
     [Fact]
@@ -160,6 +179,23 @@ public sealed class ArgumentValidationTests
         Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
             () => DateOnly.TryParseExact(
                 string.Empty, [string.Empty], CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out dateOnly)).ParamName);
+
+        // malformed format string - TryParseExact must now throw instead of silently returning false
+        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
+            () => DateOnly.TryParseExact(string.Empty, @"MM'-'\", CultureInfo.InvariantCulture, DateTimeStyles.None, out dateOnly)).Message);
+
+        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
+            () => DateOnly.TryParseExact(string.Empty.AsSpan(), @"\MM'".AsSpan(), CultureInfo.InvariantCulture, DateTimeStyles.None, out dateOnly)).Message);
+
+        // a malformed trailing entry must be caught even if an earlier format would have matched
+        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
+            () => DateOnly.TryParseExact(
+                DateOnlyValue.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), ["yyyy-MM-dd", @"MM'-'\"], CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out dateOnly)).Message);
+
+        // invalid style must take priority over a malformed format, not the other way around
+        Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
+            () => DateOnly.TryParseExact(string.Empty, @"MM'-'\", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out dateOnly)).ParamName);
 
         Assert.False(DateOnly.TryParseExact("aa-bb-cc", "dd-MM-YY", out dateOnly));
         Assert.Equal(default, dateOnly);
@@ -257,6 +293,23 @@ public sealed class ArgumentValidationTests
         Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
             () => TimeOnly.ParseExact(
                 string.Empty, [string.Empty], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)).ParamName);
+
+        // malformed format string (unterminated literal / dangling escape) - approximates upstream's
+        // Argument_BadFormatSpecifier failure, since this backport can't detect it the same way upstream does
+        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
+            () => TimeOnly.ParseExact(string.Empty, @"mm'-'\", CultureInfo.InvariantCulture)).Message);
+
+        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
+            () => TimeOnly.ParseExact(string.Empty, @"\mm'", CultureInfo.InvariantCulture)).Message);
+
+        // a malformed trailing entry must be caught even if an earlier format would have matched
+        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
+            () => TimeOnly.ParseExact(
+                TimeOnlyValue.ToString("HH:mm:ss", CultureInfo.InvariantCulture), ["HH:mm:ss", @"mm'-'\"], CultureInfo.InvariantCulture)).Message);
+
+        // invalid style must take priority over a malformed format, not the other way around
+        Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
+            () => TimeOnly.ParseExact(string.Empty, @"mm'-'\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)).ParamName);
     }
 
     [Fact]
@@ -306,6 +359,23 @@ public sealed class ArgumentValidationTests
         Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
             () => TimeOnly.TryParseExact(
                 string.Empty, [string.Empty], CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out timeOnly)).ParamName);
+
+        // malformed format string - TryParseExact must now throw instead of silently returning false
+        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
+            () => TimeOnly.TryParseExact(string.Empty, @"mm'-'\", CultureInfo.InvariantCulture, DateTimeStyles.None, out timeOnly)).Message);
+
+        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
+            () => TimeOnly.TryParseExact(string.Empty.AsSpan(), @"\mm'".AsSpan(), CultureInfo.InvariantCulture, DateTimeStyles.None, out timeOnly)).Message);
+
+        // a malformed trailing entry must be caught even if an earlier format would have matched
+        Assert.Equal(BadFormatSpecifierMessage, Assert.Throws<FormatException>(
+            () => TimeOnly.TryParseExact(
+                TimeOnlyValue.ToString("HH:mm:ss", CultureInfo.InvariantCulture), ["HH:mm:ss", @"mm'-'\"], CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out timeOnly)).Message);
+
+        // invalid style must take priority over a malformed format, not the other way around
+        Assert.Equal(StyleArgumentName, Assert.Throws<ArgumentException>(
+            () => TimeOnly.TryParseExact(string.Empty, @"mm'-'\", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out timeOnly)).ParamName);
 
         Assert.False(TimeOnly.TryParseExact("aa-bb-cc", "dd-MM-YY", out timeOnly));
         Assert.Equal(default, timeOnly);

--- a/DateTimeOnly/DateOnly.cs
+++ b/DateTimeOnly/DateOnly.cs
@@ -312,6 +312,11 @@ namespace System
         /// <returns>An object that is equivalent to the date contained in s, as specified by format, provider, and style.</returns>
         public static DateOnly ParseExact(ReadOnlySpan<char> s, [StringSyntax(StringSyntaxAttribute.DateOnlyFormat)] ReadOnlySpan<char> format, IFormatProvider? provider = default, DateTimeStyles style = DateTimeStyles.None)
         {
+            if ((style & ~DateTimeStyles.AllowWhiteSpaces) == 0)
+            {
+                DateTimeParse.ThrowOnBadFormatSpecifier(format);
+            }
+
             ParseFailureKind result = TryParseExactInternal(s, format, provider, style, out DateOnly dateOnly);
 
             if (result != ParseFailureKind.None)
@@ -344,7 +349,7 @@ namespace System
         {
             if ((style & ~DateTimeStyles.AllowWhiteSpaces) == 0)
             {
-                ThrowOnBadFormatSpecifier(formats);
+                DateTimeParse.ThrowOnBadFormatSpecifier(formats);
             }
 
             ParseFailureKind result = TryParseExactInternal(s, formats, provider, style, out DateOnly dateOnly);
@@ -505,8 +510,11 @@ namespace System
                 throw new ArgumentException(SR.Argument_InvalidDateStyles, nameof(style));
             }
 
+            DateTimeParse.ThrowOnBadFormatSpecifier(format);
+
             return TryParseExactInternal(s, format, provider, style, out result) == ParseFailureKind.None;
         }
+
         private static ParseFailureKind TryParseExactInternal(ReadOnlySpan<char> s, ReadOnlySpan<char> format, IFormatProvider? provider, DateTimeStyles style, out DateOnly result)
         {
             if ((style & ~DateTimeStyles.AllowWhiteSpaces) != 0)
@@ -576,25 +584,9 @@ namespace System
                 throw new ArgumentException(SR.Argument_InvalidDateStyles, nameof(style));
             }
 
-            ThrowOnBadFormatSpecifier(formats);
+            DateTimeParse.ThrowOnBadFormatSpecifier(formats);
 
             return TryParseExactInternal(s, formats, provider, style, out result) == ParseFailureKind.None;
-        }
-
-        private static void ThrowOnBadFormatSpecifier(string?[]? formats)
-        {
-            if (formats == null)
-            {
-                return;
-            }
-
-            for (int i = 0; i < formats.Length; i++)
-            {
-                if (string.IsNullOrEmpty(formats[i]))
-                {
-                    throw new FormatException(SR.Argument_BadFormatSpecifier);
-                }
-            }
         }
 
         private static ParseFailureKind TryParseExactInternal(ReadOnlySpan<char> s, string?[]? formats, IFormatProvider? provider, DateTimeStyles style, out DateOnly result)

--- a/DateTimeOnly/Helpers/DateTimeFormat.cs
+++ b/DateTimeOnly/Helpers/DateTimeFormat.cs
@@ -34,8 +34,10 @@ internal static class DateTimeFormat
     // Approximates the "is this format specifier malformed" check that the real .NET's internal
     // parsing engine performs as a side effect of walking format and input together (exposed via
     // DateTimeResult.failure), which isn't reachable through the public DateTime.TryParseExact API
-    // this backport delegates to. Deliberately checks only quote/escape balance, not specifier
-    // validity for a specific type - that's a separate concern already handled via ParseFlags masks.
+    // this backport delegates to. Deliberately checks only quote/escape balance, not whether a
+    // specifier is the wrong type for DateOnly/TimeOnly (e.g. an hour specifier in a DateOnly
+    // format) - that's a distinct, separate concern from a malformed format string, out of scope
+    // here.
     internal static bool IsWellFormedCustomFormat(ReadOnlySpan<char> format)
     {
         var i = 0;

--- a/DateTimeOnly/Helpers/DateTimeFormat.cs
+++ b/DateTimeOnly/Helpers/DateTimeFormat.cs
@@ -31,6 +31,53 @@ internal static class DateTimeFormat
 #endif
     }
 
+    // Approximates the "is this format specifier malformed" check that the real .NET's internal
+    // parsing engine performs as a side effect of walking format and input together (exposed via
+    // DateTimeResult.failure), which isn't reachable through the public DateTime.TryParseExact API
+    // this backport delegates to. Deliberately checks only quote/escape balance, not specifier
+    // validity for a specific type - that's a separate concern already handled via ParseFlags masks.
+    internal static bool IsWellFormedCustomFormat(ReadOnlySpan<char> format)
+    {
+        var i = 0;
+
+        while (i < format.Length)
+        {
+            switch (format[i])
+            {
+                case '\\':
+                    if (i == format.Length - 1)
+                    {
+                        return false;
+                    }
+
+                    i += 2;
+                    break;
+
+                case '\'':
+                case '"':
+                    var quoteChar = format[i++];
+                    while (i < format.Length && format[i] != quoteChar)
+                    {
+                        i++;
+                    }
+
+                    if (i >= format.Length)
+                    {
+                        return false;
+                    }
+
+                    i++;
+                    break;
+
+                default:
+                    i++;
+                    break;
+            }
+        }
+
+        return true;
+    }
+
     // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Global
     internal static bool IsValidCustomDateOnlyFormat(ReadOnlySpan<char> format, bool throwOnError)
     {

--- a/DateTimeOnly/Helpers/DateTimeParse.cs
+++ b/DateTimeOnly/Helpers/DateTimeParse.cs
@@ -58,6 +58,30 @@ internal static class DateTimeParse
 
     private static string[] GetValidTimeOnlyFormatStrings(DateTimeFormatInfo dtfi) =>
         ValidTimeOnlyFormatSpecifiers.SelectMany(dtfi.GetAllDateTimePatterns).ToArray();
+
+    internal static void ThrowOnBadFormatSpecifier(ReadOnlySpan<char> format)
+    {
+        if (!DateTimeFormat.IsWellFormedCustomFormat(format))
+        {
+            throw new FormatException(SR.Argument_BadFormatSpecifier);
+        }
+    }
+
+    internal static void ThrowOnBadFormatSpecifier(string?[]? formats)
+    {
+        if (formats == null)
+        {
+            return;
+        }
+
+        for (int i = 0; i < formats.Length; i++)
+        {
+            if (string.IsNullOrEmpty(formats[i]) || !DateTimeFormat.IsWellFormedCustomFormat(formats[i].AsSpan()))
+            {
+                throw new FormatException(SR.Argument_BadFormatSpecifier);
+            }
+        }
+    }
 }
 
 #pragma warning disable IDE0079

--- a/DateTimeOnly/TimeOnly.cs
+++ b/DateTimeOnly/TimeOnly.cs
@@ -479,6 +479,11 @@ namespace System
         /// <returns>An object that is equivalent to the time contained in s, as specified by format, provider, and style.</returns>
         public static TimeOnly ParseExact(ReadOnlySpan<char> s, [StringSyntax(StringSyntaxAttribute.TimeOnlyFormat)] ReadOnlySpan<char> format, IFormatProvider? provider = default, DateTimeStyles style = DateTimeStyles.None)
         {
+            if ((style & ~DateTimeStyles.AllowWhiteSpaces) == 0)
+            {
+                DateTimeParse.ThrowOnBadFormatSpecifier(format);
+            }
+
             ParseFailureKind result = TryParseExactInternal(s, format, provider, style, out TimeOnly timeOnly);
             if (result != ParseFailureKind.None)
             {
@@ -510,7 +515,7 @@ namespace System
         {
             if ((style & ~DateTimeStyles.AllowWhiteSpaces) == 0)
             {
-                ThrowOnBadFormatSpecifier(formats);
+                DateTimeParse.ThrowOnBadFormatSpecifier(formats);
             }
 
             ParseFailureKind result = TryParseExactInternal(s, formats, provider, style, out TimeOnly timeOnly);
@@ -673,6 +678,8 @@ namespace System
                 throw new ArgumentException(SR.Argument_InvalidDateStyles, nameof(style));
             }
 
+            DateTimeParse.ThrowOnBadFormatSpecifier(format);
+
             return TryParseExactInternal(s, format, provider, style, out result) == ParseFailureKind.None;
         }
 
@@ -745,25 +752,9 @@ namespace System
                 throw new ArgumentException(SR.Argument_InvalidDateStyles, nameof(style));
             }
 
-            ThrowOnBadFormatSpecifier(formats);
+            DateTimeParse.ThrowOnBadFormatSpecifier(formats);
 
             return TryParseExactInternal(s, formats, provider, style, out result) == ParseFailureKind.None;
-        }
-
-        private static void ThrowOnBadFormatSpecifier(string?[]? formats)
-        {
-            if (formats == null)
-            {
-                return;
-            }
-
-            for (int i = 0; i < formats.Length; i++)
-            {
-                if (string.IsNullOrEmpty(formats[i]))
-                {
-                    throw new FormatException(SR.Argument_BadFormatSpecifier);
-                }
-            }
         }
 
         private static ParseFailureKind TryParseExactInternal(ReadOnlySpan<char> s, string?[]? formats, IFormatProvider? provider, DateTimeStyles style, out TimeOnly result)


### PR DESCRIPTION
## Summary

Closes #119.

`DateOnly`/`TimeOnly` `TryParseExact` silently returned `false` for a malformed custom format string (e.g. an unterminated quoted literal like `"MM'-'\\"`), instead of throwing like `ParseExact` already does and like upstream `dotnet/runtime`'s `TryParseExact` does.

## Why this is an approximation, not a port

Upstream detects this via `DateTimeResult.failure`, a field set by their *internal* `DateTimeParse` engine as a side effect of walking the format string and input together. That engine isn't reachable through the public API surface this backport is built on — our `DateTimeParse.TryParseExact` delegates to the public `System.DateTime.TryParseExact`, which I verified empirically collapses "bad format string" and "input didn't match" into the same `false`, with nothing left to distinguish them by afterward.

So this closes the gap with an independently-derived check, not upstream's mechanism — see the [design discussion on the issue](https://github.com/OlegRa/System.DateTimeOnly/issues/119) for the full reasoning, including why upstream's own `IsValidCustomDateOnlyFormat`/`IsValidCustomTimeOnlyFormat` (which already duplicate this same quote/escape walk between the two types, even in the real dotnet/runtime source) weren't extended for this instead.

## Changes

- `Helpers/DateTimeFormat.cs`: new `IsWellFormedCustomFormat(ReadOnlySpan<char>)` — quote/escape balance only, deliberately **not** the specifier-type restriction `IsValidCustomDateOnlyFormat`/`IsValidCustomTimeOnlyFormat` have (that's a separate concern, already handled via `ParseFlagsDateMask`/`ParseFlagsTimeMask`). One shared function since this rule has no type-specific behavior.
- `Helpers/DateTimeParse.cs`: two new `ThrowOnBadFormatSpecifier` overloads (`ReadOnlySpan<char>` and `string?[]?`).
- `DateOnly.cs`/`TimeOnly.cs`: the private per-type `ThrowOnBadFormatSpecifier(string?[]?)` introduced by #118 is removed — moved to the shared class above, so this is a net reduction in duplicated code, not just avoidance of new duplication. Both `ParseExact`/`TryParseExact` (single-format overloads) now call the shared checker eagerly, before ever calling `TryParseExactInternal` — mirroring the shape #118 already established for the `formats[]` overload. `TryParseExactInternal` isn't touched at all, for either overload, either type.
- Invalid `DateTimeStyles` still takes precedence over a malformed format when both are present, using the same gating pattern the Copilot review caught and fixed for #118 (`ParseExact` gates the check on style already being valid; `TryParseExact` already throws for style first, so the format check simply runs after).

## Tests

Added per type: malformed single-format cases (unterminated literal, dangling escape) for both `ParseExact` and `TryParseExact`, a `formats[]` case with a well-formed matching entry plus a malformed trailing one (proving the eager array check still catches it), and a precedence case (invalid style + malformed format together → style error wins).

## Test plan

- [x] `dotnet build -c Debug` — succeeds, 0 warnings/errors
- [x] `dotnet test` — 169/169 passed