### PR TITLE
Add IUtf8SpanFormattable support to DateOnly/TimeOnly

### DIFF
--- a/DateTimeOnly.Tests/ArgumentValidationTests.cs
+++ b/DateTimeOnly.Tests/ArgumentValidationTests.cs
@@ -49,8 +49,8 @@ public sealed class ArgumentValidationTests
     [Fact]
     public void DateOnlyTryFormatValidationWorkedTest()
     {
-        Assert.Throws<FormatException>(() => DateOnlyValue.TryFormat([], out _, "X".AsSpan()));
-        Assert.Throws<FormatException>(() => DateOnlyValue.TryFormat([], out _, "KK".AsSpan()));
+        Assert.Throws<FormatException>(() => DateOnlyValue.TryFormat(Span<char>.Empty, out _, "X".AsSpan()));
+        Assert.Throws<FormatException>(() => DateOnlyValue.TryFormat(Span<char>.Empty, out _, "KK".AsSpan()));
     }
 
     [Fact]
@@ -229,8 +229,8 @@ public sealed class ArgumentValidationTests
     [Fact]
     public void TimeOnlyTryFormatValidationWorkedTest()
     {
-        Assert.Throws<FormatException>(() => TimeOnlyValue.TryFormat([], out _, "X".AsSpan()));
-        Assert.Throws<FormatException>(() => TimeOnlyValue.TryFormat([], out _, "kk".AsSpan()));
+        Assert.Throws<FormatException>(() => TimeOnlyValue.TryFormat(Span<char>.Empty, out _, "X".AsSpan()));
+        Assert.Throws<FormatException>(() => TimeOnlyValue.TryFormat(Span<char>.Empty, out _, "kk".AsSpan()));
     }
 
     [Fact]

--- a/DateTimeOnly.Tests/DateOnlyTests.cs
+++ b/DateTimeOnly.Tests/DateOnlyTests.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text;
 using Xunit;
 
 namespace System.Tests;
@@ -541,5 +542,44 @@ public class DateOnlyTests
         });
         Assert.Throws<FormatException>(() => $"{dateOnly:u}");
         Assert.Throws<FormatException>(() => $"{dateOnly:hh-ss}");
+    }
+
+    [Fact]
+    public static void Utf8TryFormatTest()
+    {
+        Span<byte> buffer = stackalloc byte[100];
+        DateOnly dateOnly = DateOnly.FromDateTime(DateTime.Today);
+
+        Assert.True(dateOnly.TryFormat(buffer, out int bytesWritten));
+        AssertUtf8Matches(dateOnly.ToString(), buffer, bytesWritten);
+
+        Assert.True(dateOnly.TryFormat(buffer, out bytesWritten, "o".AsSpan()));
+        Assert.Equal(10, bytesWritten);
+        AssertUtf8Matches(dateOnly.ToString("o"), buffer, bytesWritten);
+
+        Assert.True(dateOnly.TryFormat(buffer, out bytesWritten, "R".AsSpan()));
+        Assert.Equal(16, bytesWritten);
+        AssertUtf8Matches(dateOnly.ToString("R"), buffer, bytesWritten);
+
+        // a custom format long enough to overflow the fast-path's small stack buffer must still work
+        string longCustomFormat = string.Concat(System.Linq.Enumerable.Repeat("'x'yyyy-MM-dd", 6));
+        Assert.True(dateOnly.TryFormat(buffer, out bytesWritten, longCustomFormat.AsSpan()));
+        AssertUtf8Matches(dateOnly.ToString(longCustomFormat), buffer, bytesWritten);
+
+        Assert.False(dateOnly.TryFormat(buffer.Slice(0, 3), out bytesWritten));
+        Assert.False(dateOnly.TryFormat(buffer.Slice(0, 3), out bytesWritten, "r".AsSpan()));
+        Assert.False(dateOnly.TryFormat(buffer.Slice(0, 3), out bytesWritten, "O".AsSpan()));
+
+        Assert.Throws<FormatException>(() => {
+            Span<byte> buff = stackalloc byte[100];
+            dateOnly.TryFormat(buff, out bytesWritten, "u".AsSpan());
+        });
+        Assert.Throws<FormatException>(() => {
+            Span<byte> buff = stackalloc byte[100];
+            dateOnly.TryFormat(buff, out bytesWritten, "hh-ss".AsSpan());
+        });
+
+        static void AssertUtf8Matches(string expected, Span<byte> actualBuffer, int bytesWritten) =>
+            Assert.Equal(expected, Encoding.UTF8.GetString(actualBuffer.Slice(0, bytesWritten).ToArray()));
     }
 }

--- a/DateTimeOnly.Tests/TimeOnlyTests.cs
+++ b/DateTimeOnly.Tests/TimeOnlyTests.cs
@@ -4,6 +4,7 @@
 // ReSharper disable All
 
 using System.Globalization;
+using System.Text;
 using Xunit;
 
 using AssertExtensions=Xunit.Assert;
@@ -596,5 +597,44 @@ public class TimeOnlyTests
         });
         Assert.Throws<FormatException>(() => $"{timeOnly:u}");
         Assert.Throws<FormatException>(() => $"{timeOnly:dd-yyyy}");
+    }
+
+    [Fact]
+    public static void Utf8TryFormatTest()
+    {
+        Span<byte> buffer = stackalloc byte[100];
+        TimeOnly timeOnly = TimeOnly.FromDateTime(DateTime.Now);
+
+        Assert.True(timeOnly.TryFormat(buffer, out int bytesWritten));
+        AssertUtf8Matches(timeOnly.ToString(), buffer, bytesWritten);
+
+        Assert.True(timeOnly.TryFormat(buffer, out bytesWritten, "o".AsSpan()));
+        Assert.Equal(16, bytesWritten);
+        AssertUtf8Matches(timeOnly.ToString("o"), buffer, bytesWritten);
+
+        Assert.True(timeOnly.TryFormat(buffer, out bytesWritten, "R".AsSpan()));
+        Assert.Equal(8, bytesWritten);
+        AssertUtf8Matches(timeOnly.ToString("R"), buffer, bytesWritten);
+
+        // a custom format long enough to overflow the fast-path's small stack buffer must still work
+        string longCustomFormat = string.Concat(System.Linq.Enumerable.Repeat("'x'HH:mm:ss", 6));
+        Assert.True(timeOnly.TryFormat(buffer, out bytesWritten, longCustomFormat.AsSpan()));
+        AssertUtf8Matches(timeOnly.ToString(longCustomFormat), buffer, bytesWritten);
+
+        Assert.False(timeOnly.TryFormat(buffer.Slice(0, 3), out bytesWritten));
+        Assert.False(timeOnly.TryFormat(buffer.Slice(0, 3), out bytesWritten, "r".AsSpan()));
+        Assert.False(timeOnly.TryFormat(buffer.Slice(0, 3), out bytesWritten, "O".AsSpan()));
+
+        Assert.Throws<FormatException>(() => {
+            Span<byte> buff = stackalloc byte[100];
+            timeOnly.TryFormat(buff, out bytesWritten, "u".AsSpan());
+        });
+        Assert.Throws<FormatException>(() => {
+            Span<byte> buff = stackalloc byte[100];
+            timeOnly.TryFormat(buff, out bytesWritten, "dd-yyyy".AsSpan());
+        });
+
+        static void AssertUtf8Matches(string expected, Span<byte> actualBuffer, int bytesWritten) =>
+            Assert.Equal(expected, Encoding.UTF8.GetString(actualBuffer.Slice(0, bytesWritten).ToArray()));
     }
 }

--- a/DateTimeOnly/CompatibilitySuppressions.xml
+++ b/DateTimeOnly/CompatibilitySuppressions.xml
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
-<Suppressions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.IUtf8SpanFormattable</Target>
+    <Left>ref/netstandard2.1/Portable.System.DateTimeOnly.dll</Left>
+    <Right>ref/net6.0/Portable.System.DateTimeOnly.dll</Right>
+  </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:System.DateOnly.Deconstruct(System.Int32@,System.Int32@,System.Int32@)</Target>
@@ -16,6 +22,12 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:System.DateOnly.Parse(System.String,System.IFormatProvider)</Target>
+    <Left>ref/netstandard2.1/Portable.System.DateTimeOnly.dll</Left>
+    <Right>ref/net6.0/Portable.System.DateTimeOnly.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.DateOnly.TryFormat(System.Span{System.Byte},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)</Target>
     <Left>ref/netstandard2.1/Portable.System.DateTimeOnly.dll</Left>
     <Right>ref/net6.0/Portable.System.DateTimeOnly.dll</Right>
   </Suppression>
@@ -39,13 +51,7 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.TimeOnly.Deconstruct(System.Int32@,System.Int32@)</Target>
-    <Left>ref/netstandard2.1/Portable.System.DateTimeOnly.dll</Left>
-    <Right>ref/net6.0/Portable.System.DateTimeOnly.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.TimeOnly.Deconstruct(System.Int32@,System.Int32@,System.Int32@)</Target>
+    <Target>M:System.TimeOnly.Deconstruct(System.Int32@,System.Int32@,System.Int32@,System.Int32@,System.Int32@)</Target>
     <Left>ref/netstandard2.1/Portable.System.DateTimeOnly.dll</Left>
     <Right>ref/net6.0/Portable.System.DateTimeOnly.dll</Right>
   </Suppression>
@@ -57,7 +63,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.TimeOnly.Deconstruct(System.Int32@,System.Int32@,System.Int32@,System.Int32@,System.Int32@)</Target>
+    <Target>M:System.TimeOnly.Deconstruct(System.Int32@,System.Int32@,System.Int32@)</Target>
+    <Left>ref/netstandard2.1/Portable.System.DateTimeOnly.dll</Left>
+    <Right>ref/net6.0/Portable.System.DateTimeOnly.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.TimeOnly.Deconstruct(System.Int32@,System.Int32@)</Target>
     <Left>ref/netstandard2.1/Portable.System.DateTimeOnly.dll</Left>
     <Right>ref/net6.0/Portable.System.DateTimeOnly.dll</Right>
   </Suppression>
@@ -87,6 +99,12 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.TimeOnly.TryFormat(System.Span{System.Byte},System.Int32@,System.ReadOnlySpan{System.Char},System.IFormatProvider)</Target>
+    <Left>ref/netstandard2.1/Portable.System.DateTimeOnly.dll</Left>
+    <Right>ref/net6.0/Portable.System.DateTimeOnly.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:System.TimeOnly.TryParse(System.ReadOnlySpan{System.Char},System.IFormatProvider,System.TimeOnly@)</Target>
     <Left>ref/netstandard2.1/Portable.System.DateTimeOnly.dll</Left>
     <Right>ref/net6.0/Portable.System.DateTimeOnly.dll</Right>
@@ -94,6 +112,18 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:System.TimeOnly.TryParse(System.String,System.IFormatProvider,System.TimeOnly@)</Target>
+    <Left>ref/netstandard2.1/Portable.System.DateTimeOnly.dll</Left>
+    <Right>ref/net6.0/Portable.System.DateTimeOnly.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:System.DateOnly</Target>
+    <Left>ref/netstandard2.1/Portable.System.DateTimeOnly.dll</Left>
+    <Right>ref/net6.0/Portable.System.DateTimeOnly.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:System.TimeOnly</Target>
     <Left>ref/netstandard2.1/Portable.System.DateTimeOnly.dll</Left>
     <Right>ref/net6.0/Portable.System.DateTimeOnly.dll</Right>
   </Suppression>

--- a/DateTimeOnly/DateOnly.cs
+++ b/DateTimeOnly/DateOnly.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Text;
 
 namespace System
 {
@@ -21,7 +22,8 @@ namespace System
         : IComparable,
           IComparable<DateOnly>,
           IEquatable<DateOnly>,
-          ISpanFormattable
+          ISpanFormattable,
+          IUtf8SpanFormattable
     {
         private readonly int _dayNumber;
 
@@ -854,6 +856,65 @@ namespace System
             }
 
             return DateTimeFormat.TryFormat(GetEquivalentDateTime(), destination, out charsWritten, format, provider);
+        }
+
+        /// <summary>
+        /// Tries to format the value of the current DateOnly instance as UTF-8 into the provided span of bytes.
+        /// </summary>
+        /// <param name="utf8Destination">When this method returns, this instance's value formatted as a span of UTF-8 bytes.</param>
+        /// <param name="bytesWritten">When this method returns, the number of bytes that were written in utf8Destination.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that defines the acceptable format for utf8Destination.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for utf8Destination.</param>
+        /// <returns>true if the formatting was successful; otherwise, false.</returns>
+        /// <remarks>
+        /// This backport can't format directly into UTF-8 the way the real .NET 8+ implementation does, since that
+        /// relies on internal BCL primitives unavailable here. On netstandard2.1 this still avoids allocating in the
+        /// common case (formats into a stack-allocated char buffer, then encodes that span directly into
+        /// <paramref name="utf8Destination"/>); on netstandard2.0/net462 it always allocates internally, since
+        /// neither target framework exposes a way to encode UTF-8 straight into a caller-supplied Span&lt;byte&gt;.
+        /// </remarks>
+        public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.DateOnlyFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+#if NETSTANDARD2_1_OR_GREATER
+            Span<char> charBuffer = stackalloc char[64];
+            if (TryFormat(charBuffer, out int charsWritten, format, provider))
+            {
+                ReadOnlySpan<char> formatted = charBuffer.Slice(0, charsWritten);
+                if (Encoding.UTF8.GetByteCount(formatted) > utf8Destination.Length)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                bytesWritten = Encoding.UTF8.GetBytes(formatted, utf8Destination);
+                return true;
+            }
+
+            // the stack buffer above is sized generously for standard/short custom formats; an
+            // unbounded custom literal is the only realistic way to overflow it
+            string overflowFormatted = ToString(format.Length == 0 ? null : format.ToString(), provider);
+            int overflowByteCount = Encoding.UTF8.GetByteCount(overflowFormatted);
+            if (overflowByteCount > utf8Destination.Length)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            bytesWritten = Encoding.UTF8.GetBytes(overflowFormatted, utf8Destination);
+            return true;
+#else
+            string formatted = ToString(format.Length == 0 ? null : format.ToString(), provider);
+            int byteCount = Encoding.UTF8.GetByteCount(formatted);
+            if (byteCount > utf8Destination.Length)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            Encoding.UTF8.GetBytes(formatted).AsSpan().CopyTo(utf8Destination);
+            bytesWritten = byteCount;
+            return true;
+#endif
         }
 
         //

--- a/DateTimeOnly/IUtf8SpanFormattable.cs
+++ b/DateTimeOnly/IUtf8SpanFormattable.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// ReSharper disable All
+
+namespace System
+{
+    /// <summary>Provides functionality to format the string representation of an object into a span as UTF-8 bytes.</summary>
+    public interface IUtf8SpanFormattable
+    {
+        /// <summary>Tries to format the value of the current instance into the provided span of bytes as UTF-8.</summary>
+        /// <param name="utf8Destination">When this method returns, this instance's value formatted as a span of bytes.</param>
+        /// <param name="bytesWritten">When this method returns, the number of bytes that were written in <paramref name="utf8Destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that defines the acceptable format for <paramref name="utf8Destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for <paramref name="utf8Destination"/>.</param>
+        /// <returns><see langword="true"/> if the formatting was successful; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// An implementation of this interface should produce the same UTF-8 bytes as an implementation of <see cref="IFormattable.ToString(string?, IFormatProvider?)"/>
+        /// on the same type would produce as UTF-16 characters.
+        /// TryFormat should return <see langword="false"/> only if there is not enough space in the destination buffer. Any other failures should throw an exception.
+        /// </remarks>
+        bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider);
+    }
+}

--- a/DateTimeOnly/TimeOnly.cs
+++ b/DateTimeOnly/TimeOnly.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace System
 {
@@ -22,7 +23,8 @@ namespace System
         : IComparable,
           IComparable<TimeOnly>,
           IEquatable<TimeOnly>,
-          ISpanFormattable
+          ISpanFormattable,
+          IUtf8SpanFormattable
     {
         // represent the number of ticks map to the time of the day. 1 ticks = 100-nanosecond in time measurements.
         private readonly long _ticks;
@@ -1023,6 +1025,65 @@ namespace System
             }
 
             return DateTimeFormat.TryFormat(ToDateTime(), destination, out charsWritten, format, provider);
+        }
+
+        /// <summary>
+        /// Tries to format the value of the current TimeOnly instance as UTF-8 into the provided span of bytes.
+        /// </summary>
+        /// <param name="utf8Destination">When this method returns, this instance's value formatted as a span of UTF-8 bytes.</param>
+        /// <param name="bytesWritten">When this method returns, the number of bytes that were written in utf8Destination.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that defines the acceptable format for utf8Destination.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for utf8Destination.</param>
+        /// <returns>true if the formatting was successful; otherwise, false.</returns>
+        /// <remarks>
+        /// This backport can't format directly into UTF-8 the way the real .NET 8+ implementation does, since that
+        /// relies on internal BCL primitives unavailable here. On netstandard2.1 this still avoids allocating in the
+        /// common case (formats into a stack-allocated char buffer, then encodes that span directly into
+        /// <paramref name="utf8Destination"/>); on netstandard2.0/net462 it always allocates internally, since
+        /// neither target framework exposes a way to encode UTF-8 straight into a caller-supplied Span&lt;byte&gt;.
+        /// </remarks>
+        public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.TimeOnlyFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+#if NETSTANDARD2_1_OR_GREATER
+            Span<char> charBuffer = stackalloc char[64];
+            if (TryFormat(charBuffer, out int charsWritten, format, provider))
+            {
+                ReadOnlySpan<char> formatted = charBuffer.Slice(0, charsWritten);
+                if (Encoding.UTF8.GetByteCount(formatted) > utf8Destination.Length)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                bytesWritten = Encoding.UTF8.GetBytes(formatted, utf8Destination);
+                return true;
+            }
+
+            // the stack buffer above is sized generously for standard/short custom formats; an
+            // unbounded custom literal is the only realistic way to overflow it
+            string overflowFormatted = ToString(format.Length == 0 ? null : format.ToString(), provider);
+            int overflowByteCount = Encoding.UTF8.GetByteCount(overflowFormatted);
+            if (overflowByteCount > utf8Destination.Length)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            bytesWritten = Encoding.UTF8.GetBytes(overflowFormatted, utf8Destination);
+            return true;
+#else
+            string formatted = ToString(format.Length == 0 ? null : format.ToString(), provider);
+            int byteCount = Encoding.UTF8.GetByteCount(formatted);
+            if (byteCount > utf8Destination.Length)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            Encoding.UTF8.GetBytes(formatted).AsSpan().CopyTo(utf8Destination);
+            bytesWritten = byteCount;
+            return true;
+#endif
         }
 
         //


### PR DESCRIPTION
## Summary

Closes #120.

.NET 8 added `IUtf8SpanFormattable` to the BCL, and the real `DateOnly`/`TimeOnly` implement it. This backport had no equivalent. See the [design discussion on the issue](https://github.com/OlegRa/System.DateTimeOnly/issues/120) for the full per-target feasibility analysis this PR implements.

## Changes

- `IUtf8SpanFormattable.cs`: new local **public** shim interface, following the same pattern already used for `ISpanFormattable.cs` — the real interface doesn't exist in any of this project's target frameworks (it postdates even netstandard2.1).
- `DateOnly`/`TimeOnly`: implement `TryFormat(Span<byte>, out int, ReadOnlySpan<char>, IFormatProvider?)` with a **per-target strategy**, not a single allocating fallback everywhere — verified empirically (see below), not assumed:
  - **netstandard2.1**: has a `Span`-based `Encoding` API at compile time. Formats into a safe stack-allocated `char` buffer via the existing char-based `TryFormat`, then encodes that span directly into the caller's `Span<byte>` — no heap allocation in the common case. Falls back to the `ToString()`-based path only if a custom format's output overflows the stack buffer.
  - **net462/netstandard2.0**: confirmed by a failed compile that the `Span`-based `Encoding` overload genuinely doesn't exist here (not just "isn't used" — it's absent from both reference assemblies). Pointer-based alternatives are off the table since `AllowUnsafeBlocks=false` project-wide. Always goes through `ToString()` + array-based `Encoding.UTF8.GetBytes(string)`.
  - **net6.0**: unaffected either way — that TFM type-forwards to the real BCL type, and .NET 6 itself doesn't have `IUtf8SpanFormattable` (it's .NET 8+), so there's no gap to close there.
- `CompatibilitySuppressions.xml`: regenerated to add the 5 new per-target API differences this introduces (the new interface, plus the two new `TryFormat(Span<byte>, ...)` members on both types) — expected, since net6.0's forwarded type doesn't gain this member. Diffed the regenerated file against the original to confirm nothing else changed and every pre-existing suppression survived untouched.

## Tests

- `Utf8TryFormatTest` added to `DateOnlyTests.cs`/`TimeOnlyTests.cs`: verifies output matches the char-based `ToString`/`TryFormat` path byte-for-byte, too-small-destination handling (`false`, no throw), the stack-buffer-overflow fallback (a 66-char custom format against the 64-char stack buffer), and that invalid formats still throw `FormatException`.
- Caveat: the test project only targets `net481`, so these tests only exercise the allocating fallback branch through CI. I verified the netstandard2.1 fast path (including the overflow-fallback sub-path and the too-small-buffer case) manually, by forcing a throwaway probe project to consume the netstandard2.1 asset specifically (via `SetTargetFramework` + `extern alias`, confirmed via `typeof(DateOnly).Assembly.Location`) — all three scenarios produced correct, byte-identical output. Happy to discuss whether it's worth adding a permanent second test TFM to close this CI gap, but that's a larger structural change beyond this PR's scope.
- Also fixed two pre-existing tests (`DateOnlyTryFormatValidationWorkedTest`/`TimeOnlyTryFormatValidationWorkedTest`) that used a bare `[]` collection-literal for the destination buffer — now ambiguous between the `Span<char>` and new `Span<byte>` overloads. Disambiguated with `Span<char>.Empty`.

## Test plan

- [x] `dotnet build -c Debug` — succeeds across all 4 TFMs, 0 warnings/errors
- [x] `dotnet test` — 171/171 passed
- [x] Manually verified netstandard2.1 fast path + overflow fallback + too-small-buffer case against the real netstandard2.1 build output